### PR TITLE
Add contact page with Resend-powered email form

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,0 +1,42 @@
+import { Resend } from 'resend';
+
+import { contactSchema } from '@/lib/validations/contact';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const result = contactSchema.safeParse(body);
+
+    if (!result.success) {
+      return Response.json(
+        { error: result.error.issues[0].message },
+        { status: 400 },
+      );
+    }
+
+    const { name, email, message, _honey } = result.data;
+
+    if (_honey) {
+      return Response.json({ success: true });
+    }
+
+    const { error } = await resend.emails.send({
+      from: 'Portfolio Contact <onboarding@resend.dev>',
+      to: process.env.CONTACT_EMAIL as string,
+      subject: `New message from ${name}`,
+      text: `Name: ${name}\nEmail: ${email}\n\nMessage:\n${message}`,
+    });
+
+    if (error) {
+      return Response.json({ error: error.message }, { status: 500 });
+    }
+
+    return Response.json({ success: true });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : 'Internal server error';
+    return Response.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -2,10 +2,9 @@ import { Resend } from 'resend';
 
 import { contactSchema } from '@/lib/validations/contact';
 
-const resend = new Resend(process.env.RESEND_API_KEY);
-
 export async function POST(request: Request) {
   try {
+    const resend = new Resend(process.env.RESEND_API_KEY);
     const body = await request.json();
     const result = contactSchema.safeParse(body);
 

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+
+import { ContactForm } from '@/components/contact-form';
+
+const ContactPage = () => {
+  return (
+    <>
+      <div className="mx-auto w-full max-w-2xl px-6 pt-8">
+        <Link
+          href="/"
+          className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          ← Home
+        </Link>
+      </div>
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        <h1 className="mb-3 text-2xl font-bold text-foreground md:text-3xl">
+          Let&apos;s work together
+        </h1>
+        <p className="mb-10 text-base leading-relaxed text-muted-foreground">
+          Have a project in mind or just want to say hello? Fill out the form
+          and I&apos;ll get back to you as soon as I can.
+        </p>
+        <ContactForm />
+        <p className="mt-10 text-sm text-muted-foreground">
+          Prefer email? Reach me at{' '}
+          <a
+            href="mailto:aldinoanggawan@gmail.com"
+            className="text-amber-500 underline underline-offset-4 transition-colors hover:text-amber-400"
+          >
+            aldinoanggawan@gmail.com
+          </a>
+        </p>
+      </main>
+    </>
+  );
+};
+
+export default ContactPage;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
+import { Toaster } from 'sonner';
 import './globals.css';
 import { Providers } from './providers';
 import { Navbar } from '@/components/navbar';
@@ -35,6 +36,7 @@ const RootLayout = ({
         <Providers>
           <Navbar />
           {children}
+          <Toaster richColors position="bottom-right" />
         </Providers>
       </body>
     </html>

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -41,7 +41,11 @@ export const ContactForm = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      noValidate
+      className="flex flex-col gap-5"
+    >
       <input
         {...register('_honey')}
         type="text"

--- a/components/contact-form.tsx
+++ b/components/contact-form.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import {
+  contactSchema,
+  type ContactFormValues,
+} from '@/lib/validations/contact';
+
+export const ContactForm = () => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ContactFormValues>({
+    resolver: zodResolver(contactSchema),
+    defaultValues: { name: '', email: '', message: '', _honey: '' },
+  });
+
+  const onSubmit = async (data: ContactFormValues) => {
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+
+      if (!res.ok) {
+        throw new Error();
+      }
+
+      toast.success("Message sent! I'll get back to you soon.");
+      reset();
+    } catch {
+      toast.error('Something went wrong. Please try again.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+      <input
+        {...register('_honey')}
+        type="text"
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden="true"
+        className="hidden"
+      />
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="name" className="text-sm font-medium">
+          Name
+        </label>
+        <input
+          {...register('name')}
+          id="name"
+          type="text"
+          autoComplete="name"
+          placeholder="Your name"
+          className="rounded-lg border border-border bg-input/30 px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 focus:border-ring transition-colors"
+        />
+        {errors.name && (
+          <p className="text-xs text-destructive">{errors.name.message}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="email" className="text-sm font-medium">
+          Email
+        </label>
+        <input
+          {...register('email')}
+          id="email"
+          type="email"
+          autoComplete="email"
+          placeholder="your@email.com"
+          className="rounded-lg border border-border bg-input/30 px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 focus:border-ring transition-colors"
+        />
+        {errors.email && (
+          <p className="text-xs text-destructive">{errors.email.message}</p>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-1.5">
+        <label htmlFor="message" className="text-sm font-medium">
+          Message
+        </label>
+        <textarea
+          {...register('message')}
+          id="message"
+          rows={5}
+          placeholder="What's on your mind?"
+          className="resize-none rounded-lg border border-border bg-input/30 px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/50 focus:border-ring transition-colors"
+        />
+        {errors.message && (
+          <p className="text-xs text-destructive">{errors.message.message}</p>
+        )}
+      </div>
+
+      <Button
+        type="submit"
+        disabled={isSubmitting}
+        size="lg"
+        className="self-start bg-primary text-primary-foreground hover:bg-primary/90"
+      >
+        {isSubmitting ? 'Sending...' : 'Send message'}
+      </Button>
+    </form>
+  );
+};

--- a/components/sections/about-teaser.tsx
+++ b/components/sections/about-teaser.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 export const AboutTeaser = () => {
   return (
     <section className="px-6 py-24 mx-auto max-w-4xl w-full">
@@ -13,12 +15,12 @@ export const AboutTeaser = () => {
           practitioner. I care about code quality, clear communication with
           non-technical stakeholders, and sustainable pace.
         </p>
-        <a
+        <Link
           href="/about"
           className="text-sm font-medium text-primary underline-offset-4 hover:underline"
         >
           About me →
-        </a>
+        </Link>
       </div>
     </section>
   );

--- a/components/sections/contact.tsx
+++ b/components/sections/contact.tsx
@@ -15,7 +15,7 @@ export const Contact = () => {
       </p>
       <a
         href="mailto:aldinoanggawan@gmail.com"
-        className="mb-8 inline-block text-base font-medium underline underline-offset-4 hover:text-muted-foreground transition-colors"
+        className="mb-8 inline-block text-base font-medium text-amber-500 underline underline-offset-4 hover:text-amber-400 transition-colors"
       >
         aldinoanggawan@gmail.com
       </a>

--- a/components/sections/hero.tsx
+++ b/components/sections/hero.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link';
+
 import { Button } from '@/components/ui/button';
 
 export const Hero = () => {
@@ -25,7 +27,7 @@ export const Hero = () => {
           <a href="#work">View my work</a>
         </Button>
         <Button asChild variant="outline" size="lg" className="px-6">
-          <a href="#contact">Say hello</a>
+          <Link href="/contact">Say hello</Link>
         </Button>
       </div>
     </section>

--- a/lib/validations/contact.ts
+++ b/lib/validations/contact.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const contactSchema = z.object({
+  name: z.string().min(2).max(100),
+  email: z.email(),
+  message: z.string().min(10).max(2000),
+  _honey: z.string().optional(),
+});
+
+export type ContactFormValues = z.infer<typeof contactSchema>;

--- a/lib/validations/contact.ts
+++ b/lib/validations/contact.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod';
 
 export const contactSchema = z.object({
-  name: z.string().min(2).max(100),
-  email: z.email(),
-  message: z.string().min(10).max(2000),
+  name: z
+    .string()
+    .min(2, 'Name must be at least 2 characters')
+    .max(100, 'Name is too long'),
+  email: z.email('Please enter a valid email address'),
+  message: z
+    .string()
+    .min(10, 'Message must be at least 10 characters')
+    .max(2000, 'Message is too long'),
   _honey: z.string().optional(),
 });
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.11.0",
@@ -21,9 +22,13 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "react-hook-form": "^7.74.0",
+    "resend": "^6.12.2",
     "shadcn": "^4.5.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -390,6 +390,13 @@
   resolved "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz"
   integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
 
+"@hookform/resolvers@^5.2.2":
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-5.2.2.tgz#5ac16cd89501ca31671e6e9f0f5c5d762a99aa12"
+  integrity sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==
+  dependencies:
+    "@standard-schema/utils" "^0.3.0"
+
 "@humanfs/core@^0.19.2":
   version "0.19.2"
   resolved "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz"
@@ -1486,6 +1493,16 @@
   version "4.0.0"
   resolved "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz"
   integrity sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==
+
+"@stablelib/base64@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
+
+"@standard-schema/utils@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@standard-schema/utils/-/utils-0.3.0.tgz#3d5e608f16c2390c10528e98e59aef6bf73cae7b"
+  integrity sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==
 
 "@swc/helpers@0.5.15":
   version "0.5.15"
@@ -3042,6 +3059,11 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
+fast-sha256@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/fast-sha256/-/fast-sha256-1.3.0.tgz#7916ba2054eeb255982608cccd0f6660c79b7ae6"
+  integrity sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==
+
 fast-string-truncated-width@^3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz"
@@ -4484,6 +4506,11 @@ possible-typed-array-names@^1.0.0:
   resolved "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz"
   integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
 
+postal-mime@2.7.4:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/postal-mime/-/postal-mime-2.7.4.tgz#3718d1f188357ed86f906f1db8d4ca455efa4927"
+  integrity sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==
+
 postcss-selector-parser@^7.1.0:
   version "7.1.1"
   resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz"
@@ -4657,6 +4684,11 @@ react-dom@19.2.4:
   dependencies:
     scheduler "^0.27.0"
 
+react-hook-form@^7.74.0:
+  version "7.74.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.74.0.tgz#7c55ac360290e7e7a78cc3169b0f07bce11a36c0"
+  integrity sha512-yR6wHr99p9wFv686jhRWVSFhUvDvNbdUf2dKlbno8/VKOCuoNobDGC6S+M2dua9A9Yo8vpcrp8assIYbsZCQ9g==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
@@ -4740,6 +4772,14 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+resend@^6.12.2:
+  version "6.12.2"
+  resolved "https://registry.yarnpkg.com/resend/-/resend-6.12.2.tgz#4b9eb2e129c9369e25e19c8abd12913968e8c647"
+  integrity sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==
+  dependencies:
+    postal-mime "2.7.4"
+    svix "1.90.0"
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -5061,6 +5101,11 @@ sisteransi@^1.0.5:
   resolved "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
 
+sonner@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/sonner/-/sonner-2.0.7.tgz#810c1487a67ec3370126e0f400dfb9edddc3e4f6"
+  integrity sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==
+
 source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
@@ -5075,6 +5120,14 @@ stable-hash@^0.0.5:
   version "0.0.5"
   resolved "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz"
   integrity sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==
+
+standardwebhooks@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz#5faa23ceacbf9accd344361101d9e3033b64324f"
+  integrity sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==
+  dependencies:
+    "@stablelib/base64" "^1.0.0"
+    fast-sha256 "^1.3.0"
 
 statuses@^2.0.1, statuses@^2.0.2, statuses@~2.0.2:
   version "2.0.2"
@@ -5246,6 +5299,14 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
+svix@1.90.0:
+  version "1.90.0"
+  resolved "https://registry.yarnpkg.com/svix/-/svix-1.90.0.tgz#49c3a310745b05a26d322f17c0207d0c6da88dc6"
+  integrity sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==
+  dependencies:
+    standardwebhooks "1.0.0"
+    uuid "^10.0.0"
 
 tagged-tag@^1.0.0:
   version "1.0.0"
@@ -5543,6 +5604,11 @@ util-deprecate@^1.0.2:
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-10.0.0.tgz#5a95aa454e6e002725c79055fd42aaba30ca6294"
+  integrity sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==
+
 validate-npm-package-name@^7.0.1:
   version "7.0.2"
   resolved "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz"
@@ -5715,4 +5781,9 @@ zod@^3.24.1:
 "zod@^3.25 || ^4.0", "zod@^3.25.0 || ^4.0.0":
   version "4.3.6"
   resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==
+
+zod@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
- New `/contact` page with form (name, email, message).
- New `POST /api/contact` route handler with Resend integration.
- Zod schema for shared client/server validation.
- `react-hook-form` with `zodResolver` for form state.
- Sonner toast for success/error feedback.
- Honeypot field for basic spam protection.
- Hero "Say hello" button now links to `/contact`.
- Contact section email link restored to `mailto:` with amber styling.

**Note:**
Requires `RESEND_API_KEY` and `CONTACT_EMAIL` in environment variables.